### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Shows a graphic representation of the sounds captured by the microphone on Andro
 ![android_audio_waves](https://cloud.githubusercontent.com/assets/1595403/11171019/e7f21ebe-8be4-11e5-80ed-5d485dc46719.png)
 
 ###GRADLE:
+Add this to your `app/build.gradle`
 
 	repositories {
 	    	...


### PR DESCRIPTION
Added description of where exactly to add the dependencies. If app/build.gradle does not have a `repositories` block and project/build.gradle does, it might lead to a confusion as to where to add those dependencies. 