### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#Audio Waves
+# Audio Waves
 
 Shows a graphic representation of the sounds captured by the microphone on Android
 
 ![android_audio_waves](https://cloud.githubusercontent.com/assets/1595403/11171019/e7f21ebe-8be4-11e5-80ed-5d485dc46719.png)
 
-###GRADLE:
+### GRADLE:
 Add this to your `app/build.gradle`
 
 	repositories {
@@ -16,7 +16,7 @@ Add this to your `app/build.gradle`
 	        compile 'org.firezenk:audiowaves:1.1@aar'
 	}
 
-###USAGE:
+### USAGE:
 
 1. Add permission to record audio (into your Manifest)
 	
@@ -101,11 +101,11 @@ Add this to your `app/build.gradle`
     void setGradientColorEnd(int color);
 	````
 
-###MORE INFO:
+### MORE INFO:
 
 	Go to sample module
 
-###LICENSE
+### LICENSE
 
 ````
 The MIT License (MIT)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
